### PR TITLE
update: actions/download-artifact v3 to v4.2.1 in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
       version: ${{ needs.get-product-version.outputs.product-version }}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@v4.2.1
         with:
           name: rollouts-plugin-trafficrouter-consul_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos}}_${{ matrix.goarch }}.zip
           path: rollouts-plugin-trafficrouter-consul/dist/${{ matrix.goos}}/${{ matrix.goarch }}


### PR DESCRIPTION
- update: deprecated actions/download-artifact v3 to v4.2.1 in build workflow